### PR TITLE
Fix: Ensure continuous FM audio during Dual Watch

### DIFF
--- a/app/app.c
+++ b/app/app.c
@@ -369,7 +369,7 @@ Skip:
 			break;
 
 		case END_OF_RX_MODE_END:
-			RADIO_SetupRegisters(true);
+			RADIO_SetupRegisters(true, false);
 
 			#ifdef ENABLE_NOAA
 				if (IS_NOAA_CHANNEL(gRxVfo->CHANNEL_SAVE))
@@ -580,7 +580,7 @@ static void DualwatchAlternate(void)
 		}
 	}
 
-	RADIO_SetupRegisters(false);
+	RADIO_SetupRegisters(false, gFmRadioMode);
 
 	#ifdef ENABLE_NOAA
 		gDualWatchCountdown_10ms = gIsNoaaMode ? dual_watch_count_noaa_10ms : dual_watch_count_toggle_10ms;
@@ -960,7 +960,7 @@ void APP_Update(void)
 #endif
 		{
 			NOAA_IncreaseChannel();
-			RADIO_SetupRegisters(false);
+			RADIO_SetupRegisters(false, false);
 
 			gNOAA_Countdown_10ms = 7;      // 70ms
 			gScheduleNOAA        = false;
@@ -1595,7 +1595,8 @@ void APP_TimeSlice500ms(void)
 				RADIO_ConfigureChannel(0, VFO_CONFIGURE_RELOAD);
 				RADIO_ConfigureChannel(1, VFO_CONFIGURE_RELOAD);
 
-				RADIO_SetupRegisters(true);
+				// RADIO_SetupRegisters(true);
+				RADIO_SetupRegisters(true, false);
 			}
 */
 			DTMF_clear_input_box();
@@ -1694,7 +1695,7 @@ static void ALARM_Off(void)
 
 	SYSTEM_DelayMs(5);
 
-	RADIO_SetupRegisters(true);
+	RADIO_SetupRegisters(true, false);
 
 	if (gScreenToDisplay != DISPLAY_MENU)     // 1of11 .. don't close the menu
 		gRequestDisplayScreen = DISPLAY_MAIN;
@@ -2061,7 +2062,7 @@ Skip:
 		RADIO_ConfigureNOAA();
 #endif
 
-		RADIO_SetupRegisters(true);
+		RADIO_SetupRegisters(true, false);
 
 #ifdef ENABLE_DTMF_CALLING
 		gDTMF_auto_reset_time_500ms = 0;

--- a/radio.h
+++ b/radio.h
@@ -155,7 +155,7 @@ void     RADIO_ConfigureChannel(const unsigned int VFO, const unsigned int confi
 void     RADIO_ConfigureSquelchAndOutputPower(VFO_Info_t *pInfo);
 void     RADIO_ApplyOffset(VFO_Info_t *pInfo);
 void     RADIO_SelectVfos(void);
-void     RADIO_SetupRegisters(bool switchToForeground);
+void     RADIO_SetupRegisters(bool switchToForeground, bool isFmDwCheck);
 #ifdef ENABLE_NOAA
 	void RADIO_ConfigureNOAA(void);
 #endif


### PR DESCRIPTION
Modified the Dual Watch and radio setup logic to prevent FM radio audio from being interrupted when Dual Watch scans the alternate VFO.

Changes include:
- Introduced a flag `isFmDwCheck` to `RADIO_SetupRegisters`.
- When `gFmRadioMode` is true and `isFmDwCheck` is true (i.e., a Dual Watch check is occurring while FM radio is active), `RADIO_SetupRegisters` now performs a minimal set of operations to check for a signal on the alternate VFO. This minimal setup avoids disturbing the FM audio stream by not reinitializing the audio path or unnecessarily configuring the BK4819 chip for full VFO reception.
- The `DualwatchAlternate` function in `app/app.c` now passes `gFmRadioMode` as the `isFmDwCheck` flag to `RADIO_SetupRegisters`.
- All other call sites of `RADIO_SetupRegisters` have been updated to pass `false` for the new flag to maintain existing behavior.