### PR TITLE
Fix FM broadcast memory validation

### DIFF
--- a/app/fm.c
+++ b/app/fm.c
@@ -251,7 +251,12 @@ static void Key_DIGITS(KEY_Code_t Key, uint8_t state)
 
 		if (State == STATE_FREQ_MODE) {
 			if (gInputBoxIndex == 1) {
-				if (gInputBox[0] > 1) {
+				if (gInputBox[0] > 2) {
+					gBeepToPlay = BEEP_500HZ_60MS_DOUBLE_BEEP_OPTIONAL;
+					gInputBoxIndex = 0;
+					return;
+				}
+				else if (gInputBox[0] > 1) {
 					gInputBox[1] = gInputBox[0];
 					gInputBox[0] = 0;
 					gInputBoxIndex = 2;


### PR DESCRIPTION
## Summary
- Fixes FM broadcast memory input validation to reject invalid first digits (≥ 3)
- Adds error beep and resets input when user types digits 3-9 as first digit
- Prevents confusion when trying to access non-existent memories (30, 40, etc.)

## Problem
In FM broadcast mode, when typing a first digit ≥ 3, the system would wait for a second digit even though only 20 memories exist (01-20). This caused confusion as users could attempt to access memories like 30, 40, etc.

## Solution
Modified the input validation logic in `app/fm.c` to:
- Immediately reject first digits ≥ 3 with an error beep
- Reset input buffer to allow new valid input
- Maintain existing behavior for digits 0, 1, 2

## Test plan
- [ ] Test typing digits 3-9 as first digit → should beep and reset
- [ ] Test typing 01-09 → should work normally  
- [ ] Test typing 10-20 → should work normally
- [ ] Test typing 21+ → should beep and reject (existing behavior)