### PR TITLE
Fix FM broadcast MR mode memory input validation

### DIFF
--- a/app/fm.c
+++ b/app/fm.c
@@ -279,6 +279,13 @@ static void Key_DIGITS(KEY_Code_t Key, uint8_t state)
 				return;
 			}
 		}
+		else if (State == STATE_MR_MODE && gInputBoxIndex == 1) {
+			if (gInputBox[0] > 2) {
+				gBeepToPlay = BEEP_500HZ_60MS_DOUBLE_BEEP_OPTIONAL;
+				gInputBoxIndex = 0;
+				return;
+			}
+		}
 		else if (gInputBoxIndex == 2) {
 			uint8_t Channel;
 


### PR DESCRIPTION
## Summary
- Fixes FM broadcast MR (memory) mode input validation to reject invalid first digits (≥ 3)
- Adds error beep and resets input when user types digits 3-9 as first digit in MR mode
- Prevents confusion when trying to access non-existent memories (30, 40, etc.)

## Problem
In FM broadcast MR mode, when typing a first digit ≥ 3, the system would wait for a second digit even though only 20 FM memories exist (01-20). This caused confusion as users could attempt to access memories like 30, 40, 50, etc. which don't exist.

## Solution
Added validation logic in `app/fm.c` for MR mode specifically:
- Check if user is in MR mode and has entered first digit
- If first digit is > 2, immediately reject with error beep and reset input
- Maintains existing behavior for valid first digits (0, 1, 2)
- Preserves all existing functionality for frequency mode and 2-digit memory selection

## Technical Details
- Added new condition: `else if (State == STATE_MR_MODE && gInputBoxIndex == 1)`
- Validates `gInputBox[0] > 2` to reject invalid first digits
- Uses standard error beep (`BEEP_500HZ_60MS_DOUBLE_BEEP_OPTIONAL`)
- Resets input index to allow new valid input

## Test plan
- [ ] Test MR mode: typing digits 3-9 as first digit → should beep and reset
- [ ] Test MR mode: typing 01-09 → should work normally  
- [ ] Test MR mode: typing 10-20 → should work normally
- [ ] Test MR mode: typing 21+ → should beep and reject (existing behavior)
- [ ] Test frequency mode: ensure no regression in frequency input
- [ ] Test mode switching: ensure validation applies only to appropriate mode