### PR TITLE
Fix: Éliminer le bruit de clic en mode FM broadcast avec dualwatch activé

### DIFF
--- a/scheduler.c
+++ b/scheduler.c
@@ -82,7 +82,11 @@ void SystickHandler(void)
 	if (gCurrentFunction == FUNCTION_POWER_SAVE)
 		DECREMENT_AND_TRIGGER(gPowerSave_10ms, gPowerSaveCountdownExpired);
 
-	if (gScanStateDir == SCAN_OFF && !gCssBackgroundScan && gEeprom.DUAL_WATCH != DUAL_WATCH_OFF)
+	if (gScanStateDir == SCAN_OFF && !gCssBackgroundScan && gEeprom.DUAL_WATCH != DUAL_WATCH_OFF
+#ifdef ENABLE_FMRADIO
+		&& !gFmRadioMode
+#endif
+	)
 		if (gCurrentFunction != FUNCTION_MONITOR && gCurrentFunction != FUNCTION_TRANSMIT && gCurrentFunction != FUNCTION_RECEIVE)
 			DECREMENT_AND_TRIGGER(gDualWatchCountdown_10ms, gScheduleDualWatch);
 


### PR DESCRIPTION
## 🎯 Problème résolu

Lorsque le mode dualwatch est activé en mode FM broadcast, des clics répétitifs se produisent environ toutes les 100ms dans l'audio. Ces bruits disparaissent en mode "Main only" ou lorsqu'un signal VFO est détecté et interrompt temporairement le mode FM.

## 🔍 Analyse de la cause principale

### Architecture matérielle
La radio utilise deux puces distinctes partageant des circuits audio communs :
- **BK1080** : Récepteur FM broadcast (87.5-108 MHz)
- **BK4819** : Émetteur-récepteur VHF/UHF (walkie-talkie)

### Séquence du problème

1. **Déclenchement du scheduler (toutes les 100ms)**
   - Condition vérifiée : `gEeprom.DUAL_WATCH != DUAL_WATCH_OFF`
   - Manquait la vérification de `gFmRadioMode`
   - Timer déclenche `gScheduleDualWatch`

2. **Basculement VFO**
   - `DualwatchAlternate()` bascule entre VFO A et VFO B
   - Appelle `RADIO_SetupRegisters(false)`

3. **Reconfiguration du BK4819**
   Même en écoutant le BK1080 (FM), le BK4819 est reconfiguré :
   - `BK4819_ToggleGpioOut()` : Changements d'état GPIO
   - `BK4819_SetFrequency()` : Reprogrammation PLL
   - `BK4819_WriteRegister(BK4819_REG_48)` : Registres audio/DAC
   - `BK4819_SetupSquelch()` : Configuration squelch
   - Et nombreuses autres écritures de registres

4. **Génération de transitoires électriques**
   - **Amplificateur audio partagé** : BK1080 et BK4819 → même ampli
   - **Transitoires GPIO** : Basculement `GPIO0_PIN28_RX_ENABLE` crée des pics de tension
   - **Bruits PLL** : Verrouillage du synthétiseur de fréquence génère du bruit RF
   - **Couplage audio** : Ces transitoires se couplent dans le chemin audio
   - **Résultat** : Clics/pops audibles dans le haut-parleur

### Chronologie visuelle
```
Temps:  0ms ---------> 100ms ---------> 200ms ---------> 300ms
        |              |                |                |
        Écoute FM      CLIC!            Écoute FM        CLIC!
        (BK1080)       (Bascule VFO)    (BK1080)         (Bascule VFO)
                       (Reconfig BK4819)                 (Reconfig BK4819)
```

### Pourquoi ça ne se produit pas en "Main only"
- Dualwatch désactivé → Pas de basculement VFO
- BK4819 reste dans un état stable
- Pas d'écritures de registres = Pas de clics

### Pourquoi ça ne se produit pas lors de la détection d'un signal
- La radio quitte le mode FM : `BK1080_Init0()` éteint le BK1080
- Bascule vers BK4819 pour recevoir le signal
- Après la fin du signal, attend 5 secondes avant de retourner en FM
- Durant ces 5 secondes, le dualwatch est suspendu
- Pas de basculement VFO = Pas de clics

## ✅ Solution implémentée

### Modification (`scheduler.c`, lignes 85-91)
```c
if (gScanStateDir == SCAN_OFF && !gCssBackgroundScan && gEeprom.DUAL_WATCH != DUAL_WATCH_OFF
#ifdef ENABLE_FMRADIO
    && !gFmRadioMode  // ← Nouvelle condition ajoutée
#endif
)
    if (gCurrentFunction != FUNCTION_MONITOR && gCurrentFunction != FUNCTION_TRANSMIT && gCurrentFunction != FUNCTION_RECEIVE)
        DECREMENT_AND_TRIGGER(gDualWatchCountdown_10ms, gScheduleDualWatch);
```

### Principe
- Empêche le scheduler de déclencher le polling dualwatch en mode FM broadcast
- Cohérent avec les patterns existants (voir ligne 107-109 pour la logique similaire du scan FM)

## ✨ Comportement après le correctif

### ✅ Ce qui fonctionne
- **Mode FM broadcast** : Aucun bruit de clic avec dualwatch activé
- **Détection de signal VFO** : Continue via `CheckRadioInterrupts()` et `CheckForIncoming()`
- **Interruption FM** : Le signal BK4819 VFO interrompt toujours correctement le mode FM broadcast
- **Restauration FM** : Après 5 secondes sans activité VFO, retour automatique en mode FM
- **Dualwatch normal** : Continue de fonctionner en mode radio standard (hors FM)
- **Mode économie d'énergie** : Dualwatch en power save non affecté

### ❌ Ce qui ne fonctionne pas (intentionnel)
- Basculement VFO dualwatch pendant le broadcast FM (déjà désactivé, commentaire à `fm.c:600`)
- Indicateur d'état dualwatch en mode FM (déjà désactivé)

## 🧪 Plan de test

1. Activer le paramètre dualwatch (Menu → DW → ON)
2. Entrer en mode FM broadcast (KEY_0 ou ACTION_FM)
3. Vérifier l'absence de bruit de clic dans l'audio FM
4. Vérifier que le signal VFO (transmettre sur fréquence surveillée) interrompt le FM
5. Vérifier que le FM reprend après la fin du signal VFO (timeout 5 secondes)
6. Quitter le mode FM et vérifier le fonctionnement normal du dualwatch
7. Tester le mode économie d'énergie avec dualwatch

## 📊 Analyse d'impact

- **Fichiers modifiés** : 1 (`scheduler.c`)
- **Lignes modifiées** : ~3
- **Niveau de risque** : Faible - modification isolée avec portée claire
- **Compatibilité ascendante** : Totale - affecte uniquement un comportement déjà non fonctionnel
- **Impact sur les performances** : Négligeable - supprime du travail inutile
- **Compilation** : Compatible avec `ENABLE_FMRADIO=0` et `ENABLE_FMRADIO=1`

## 🔧 Détails techniques

### Pourquoi les gardes `#ifdef ENABLE_FMRADIO` sont nécessaires
Le projet supporte deux configurations de build :
- `ENABLE_FMRADIO=1` : Fonctionnalités FM incluses
- `ENABLE_FMRADIO=0` : FM désactivé (économie de mémoire)

Sans les gardes, la compilation échouerait avec `ENABLE_FMRADIO=0` car :
- La variable `gFmRadioMode` n'existe pas
- `app/fm.c` n'est pas compilé
- Erreur du linker : référence indéfinie à `gFmRadioMode`

### Alternative considérée
Bloquer l'exécution dans `DualwatchAlternate()` directement, mais l'approche au niveau du scheduler est plus propre et cohérente avec le code existant.

---

**Note** : Le clic est essentiellement une **diaphonie électrique** entre les deux puces radio qui partagent des composants matériels audio communs.